### PR TITLE
fix: label propagation

### DIFF
--- a/tree_learn/util/pipeline.py
+++ b/tree_learn/util/pipeline.py
@@ -41,8 +41,8 @@ def generate_tiles(cfg, forest_path, logger, return_type='voxelized'):
     if (not osp.exists(save_path_voxelized)) or (return_type == 'original' and not osp.exists(save_path_voxelized_original_idx)):
         data = load_data(forest_path)
         data, original_idx = voxelize(data, cfg.voxel_size)
-        data = np.round(data, 2)
         data = data.astype(np.float32)
+        data = np.round(data, 2)
         np.savez_compressed(save_path_voxelized, points=data[:, :3], labels=data[:, 3])
 
         if return_type == 'original':


### PR DESCRIPTION
When setting the `save_cfg.return_type` configuration option to `original`, the TreeLearn pipeline fails for some point cloud files. This is because the [propagate_preds_hash_full](https://github.com/ecker-lab/TreeLearn/blob/40f5bbf7b1d253473b43e3c4dc8dcc2af0940995/tree_learn/util/pipeline.py#L441) method does not find hash map entries for some of the voxelized points. This seems to be due to numerical issues since in the [generate_tiles](https://github.com/ecker-lab/TreeLearn/blob/40f5bbf7b1d253473b43e3c4dc8dcc2af0940995/tree_learn/util/pipeline.py#L24) method, the coordinates are rounded before being converted to `np.float32`, while in [propagate_preds_hash_full](https://github.com/ecker-lab/TreeLearn/blob/40f5bbf7b1d253473b43e3c4dc8dcc2af0940995/tree_learn/util/pipeline.py#L441), they are already of type `np.float32` when being rounded. The proposed change fixes this by shifting the rounding after the conversion to `np.float32'.